### PR TITLE
Save las location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,15 @@ All notable changes to the "base64-converter" extension will be documented in th
 ### 🔧 Improvements
 
 - Enhanced user experience by providing feedback on successful file conversions directly in the UI.
+
+## [1.2.1] - 2024-10-30
+
+### 🌟 New Features
+
+- **Save file path**:
+  - Added a feature to save the file path to global storage.
+  - When the user saves a new file, the path is stored and displayed in the UI. This allows users to easily access the saved file.
+
+### 🔧 Improvement
+
+- Enhanced user experience by providing quick access to the saved file path.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "base64-converter",
   "displayName": "Base64 converter",
   "description": "A base64 converter",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "publisher": "Xubylele",
   "icon": "assets/logo.png",
   "engines": {

--- a/src/commands/base64ToFile.ts
+++ b/src/commands/base64ToFile.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import i18n from '../I18n';
 import { convertBase64ToFile } from '../utils/base64Utils';
 
-export async function base64ToFileCommand() {
+export async function base64ToFileCommand(context: vscode.ExtensionContext) {
   const base64Input = await vscode.window.showInputBox({
     prompt: i18n.__('base64.putBase64'),
     placeHolder: 'SGVsbG8gd29ybGQh==',
@@ -13,5 +13,5 @@ export async function base64ToFileCommand() {
     return;
   }
 
-  await convertBase64ToFile(base64Input);
+  await convertBase64ToFile(context, base64Input);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,17 @@
 import * as vscode from 'vscode';
-import { base64ToFileCommand } from './commands/base64ToFile';
 import { setupI18n } from './I18n';
+import { base64ToFileCommand } from './commands/base64ToFile';
 import { openBase64ConverterView } from './views/base64ConverterView';
 
 export function activate(context: vscode.ExtensionContext) {
 	setupI18n(context);
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('extension.base64ToFile', base64ToFileCommand)
+		vscode.commands.registerCommand('extension.base64ToFile', () => base64ToFileCommand(context))
 	);
 
 	context.subscriptions.push(
-		vscode.commands.registerCommand('extension.openBase64ConverterView', openBase64ConverterView)
+		vscode.commands.registerCommand('extension.openBase64ConverterView', () => openBase64ConverterView(context))
 	);
 }
 

--- a/src/utils/base64Utils.ts
+++ b/src/utils/base64Utils.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import i18n from '../I18n';
+import { getConversionPath, saveConversionPath } from './conversionPath';
 
-export async function convertBase64ToFile(base64Input: string) {
+export async function convertBase64ToFile(context: vscode.ExtensionContext, base64Input: string) {
   const extensionOptions = ['pdf', 'txt', 'png', 'jpg', 'docx', i18n.__('base64.other')];
   const selectedExtension = await vscode.window.showQuickPick(extensionOptions, {
     placeHolder: i18n.__('base64.selectFileExtension'),
@@ -21,10 +22,12 @@ export async function convertBase64ToFile(base64Input: string) {
     return;
   }
 
+  const lastSelectedPath = getConversionPath(context);
+
   const saveUri = await vscode.window.showSaveDialog({
     saveLabel: i18n.__('base64.saveConvertedFile'),
     filters: { [i18n.__('fileUtils.allFiles')]: ['*'] },
-    defaultUri: vscode.Uri.file(`output.${fileExtension}`),
+    defaultUri: lastSelectedPath ? vscode.Uri.file(lastSelectedPath) : vscode.Uri.file(`output.${fileExtension}`),
   });
 
   if (!saveUri) {
@@ -41,6 +44,8 @@ export async function convertBase64ToFile(base64Input: string) {
         vscode.window.showInformationMessage(i18n.__('base64.saveFileAs', { fileName: saveUri.fsPath }));
       }
     });
+
+    saveConversionPath(context, saveUri.fsPath);
   } catch (error) {
     vscode.window.showErrorMessage(i18n.__('base64.errorSavingFile'));
   }

--- a/src/utils/conversionPath.ts
+++ b/src/utils/conversionPath.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+const saveConversionPath = (context: vscode.ExtensionContext, conversionPath: string) => {
+  context.globalState.update('conversion_path', conversionPath);
+};
+
+const getConversionPath = (context: vscode.ExtensionContext) => {
+  return context.globalState.get<string>('conversion_path');
+};
+
+export { saveConversionPath, getConversionPath };

--- a/src/views/base64ConverterView.ts
+++ b/src/views/base64ConverterView.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { convertBase64ToFile } from '../utils/base64Utils';
 import i18n from '../I18n';
 
-export function openBase64ConverterView() {
+export function openBase64ConverterView(context: vscode.ExtensionContext) {
   const panel = vscode.window.createWebviewPanel(
     'base64Converter',
     i18n.__('base64Converter.title'),
@@ -21,7 +21,7 @@ export function openBase64ConverterView() {
         const base64Input = message.base64String;
 
         try {
-          await convertBase64ToFile(base64Input);
+          await convertBase64ToFile(context, base64Input);
 
           panel.webview.postMessage({
             command: 'conversionSuccess',


### PR DESCRIPTION
# Pull Request Description

This PR introduces the following changes to the "Base64 Converter" VSCode extension:

## Changes in `package.json`
- **Version Update**: The extension version has been bumped from `1.2.0` to `1.2.1` to reflect new storage functionality.

## Changes in `src/commands/base64ToFile.ts`
- **Addition of `context` Parameter**: The `base64ToFileCommand` function now accepts `context` as a parameter to enable usage of `globalState` for persistent data storage across sessions.
- **Update of `convertBase64ToFile` Call**: The call to `convertBase64ToFile` now includes `context` as an argument.

## Changes in `src/extension.ts`
- **Command Registration with `context`**: Updated the registration of the `extension.base64ToFile` command to pass `context` as a parameter to `base64ToFileCommand`. The same change applies to the `openBase64ConverterView` command.

## Changes in `src/utils/base64Utils.ts`
- **Update to `convertBase64ToFile`**: The `convertBase64ToFile` function now receives `context` as a parameter to store the last selected conversion path.
- **Retrieving and Saving Conversion Path**: `getConversionPath` is used to retrieve the last save location, and `saveConversionPath` is used to store it in `globalState`.

## New File `src/utils/conversionPath.ts`
- **Path Storage Functions**: Added `saveConversionPath` and `getConversionPath` functions to allow saving and retrieving the last save location using `context.globalState`.

## Changes in `src/views/base64ConverterView.ts`
- **Addition of `context` Parameter**: The `openBase64ConverterView` function now receives `context`, allowing `convertBase64ToFile` to access global state when saving files.
